### PR TITLE
Use docker straight up

### DIFF
--- a/internal/publish/version_gateway.go
+++ b/internal/publish/version_gateway.go
@@ -57,7 +57,7 @@ func (g *versionGateway) Push(project string, name string, version string, dir s
 	}
 
 	g.logger.Debugf("Pushing %s...", fullyQualifiedRepo)
-	return runExecutable(g.logger.Writer(), "gcloud", "docker", "--", "push", fullyQualifiedRepo)
+	return runExecutable(g.logger.Writer(), "docker", "push", fullyQualifiedRepo)
 }
 
 func (g *versionGateway) build(fullyQualifiedRepo string, dir string) error {


### PR DESCRIPTION
gcloud has deprecated `gcloud docker -- push` so now we just used `docker push`.

Need to handle warnings if `gcloud auth configure-docker` has not been run.